### PR TITLE
Delete openscad from packages.x86_64

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -5,7 +5,6 @@ portaudio
 libvorbis
 gtk2
 gtkglext
-openscad
 lua
 glew
 sox


### PR DESCRIPTION
As it is no longer necessary for building space nerds in space